### PR TITLE
git.io is shutting down

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Get the latest goreleaser binary
 
 ```sh
-curl -sL http://git.io/goreleaser | bash
+curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | bash
 ```
 
 Or, if you want to lock an specific version:
 
 ```sh
-curl -sL http://git.io/goreleaser | VERSION=v0.7.0 bash
+curl -sL https://raw.githubusercontent.com/goreleaser/get/master/get | VERSION=v0.7.0 bash
 ```

--- a/latest
+++ b/latest
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-curl -s https://git.io/goreleaser | bash
+curl -s https://raw.githubusercontent.com/goreleaser/get/master/get | bash


### PR DESCRIPTION
ref https://github.blog/changelog/2022-04-25-git-io-deprecation/